### PR TITLE
Use structured entries for env snippet

### DIFF
--- a/quickstart/quickstart-login.yaml
+++ b/quickstart/quickstart-login.yaml
@@ -59,20 +59,33 @@ snippets:
     source: "quickstart/scripts/install-auth0.sh"
     language: "bash"
   env: &env
+    type: constructed
     fileName: *defaultEnvFileName
-    content: |
-      ISSUER_BASE_URL=https://%AUTH0_DOMAIN%
-      CLIENT_ID=%AUTH0_CLIENT_ID%
-
-      # 32+ character random string to encrypt the session cookie
-      #
-      # We're generating a secret for your convenience, but for production,
-      # generate your own secret using `openssl rand -hex 32`
-      SECRET=%AUTH0_SECRET%
-
-      BASE_URL=%APP_SCHEME%://%APP_DOMAIN%:%PORT%
-      PORT=%PORT%
     language: "bash"
+    entries:
+      - type: var
+        name: ISSUER_BASE_URL
+        value: "https://%AUTH0_DOMAIN%"
+      - type: var
+        name: CLIENT_ID
+        value: "%AUTH0_CLIENT_ID%"
+      - type: separator
+      - type: var
+        name: SECRET
+        value: "%AUTH0_SECRET%"
+        sensitive: true
+        comment: |
+          32+ character random string to encrypt the session cookie
+
+          We're generating a secret for your convenience, but for production,
+          generate your own secret using `openssl rand -hex 32`
+      - type: separator
+      - type: var
+        name: BASE_URL
+        value: "%APP_SCHEME%://%APP_DOMAIN%:%PORT%"
+      - type: var
+        name: PORT
+        value: "%PORT%"
   app-js: &appJs
     source: "app.js"
     language: "js"


### PR DESCRIPTION
## Summary
- Replace raw `content` string in the env snippet with structured `entries` array in `quickstart-login.yaml`
- Adds `type: constructed` and per-variable metadata (`sensitive`, `comment`, `separator`) to support richer env file generation

## Test plan
- [x] Confirm `tools/ensure-env.cjs` and `tools/check-port-and-start.cjs` still work (they only read `fileName`, which is unchanged)